### PR TITLE
Multiple code improvements - squid:S1854, squid:S1197, squid:S1609

### DIFF
--- a/src/main/java/ru/serce/jnrfuse/FuseCallbacks.java
+++ b/src/main/java/ru/serce/jnrfuse/FuseCallbacks.java
@@ -12,211 +12,253 @@ import jnr.ffi.types.uid_t;
 
 public final class FuseCallbacks {
 
+    @FunctionalInterface
     public interface GetAttrCallback {
         @Delegate
         int getattr(String path, Pointer stbuf);
     }
 
+    @FunctionalInterface
     public interface ReadlinkCallback {
         @Delegate
         int readlink(String path, Pointer buf, @size_t long size);
     }
 
+    @FunctionalInterface
     public interface MknodCallback {
         @Delegate
         int mknod(String path, @mode_t long mode, @dev_t long rdev);
     }
 
+    @FunctionalInterface
     public interface MkdirCallback {
         @Delegate
         int mkdir(String path, @mode_t long mode);
     }
 
+    @FunctionalInterface
     public interface UnlinkCallback {
         @Delegate
         int unlink(String path);
     }
 
+    @FunctionalInterface
     public interface RmdirCallback {
         @Delegate
         int rmdir(String path);
     }
 
+    @FunctionalInterface
     public interface SymlinkCallback {
         @Delegate
         int symlink(String oldpath, String newpath);
     }
 
+    @FunctionalInterface
     public interface RenameCallback {
         @Delegate
         int rename(String oldpath, String newpath);
     }
 
+    @FunctionalInterface
     public interface LinkCallback {
         @Delegate
         int link(String oldpath, String newpath);
     }
 
+    @FunctionalInterface
     public interface ChmodCallback {
         @Delegate
         int chmod(String path, @mode_t long mode);
     }
 
+    @FunctionalInterface
     public interface ChownCallback {
         @Delegate
         int chown(String path, @uid_t long uid, @gid_t long gid);
     }
 
+    @FunctionalInterface
     public interface TruncateCallback {
         @Delegate
         int truncate(String path, @off_t long size);
     }
 
+    @FunctionalInterface
     public interface OpenCallback {
         @Delegate
         int open(String path, Pointer fi);
     }
 
+    @FunctionalInterface
     public interface ReadCallback {
         @Delegate
         int read(String path, Pointer buf, @size_t long size, @off_t long offset, Pointer fi);
     }
 
+    @FunctionalInterface
     public interface WriteCallback {
         @Delegate
         int write(String path, Pointer buf, @size_t long size, @off_t long offset, Pointer fi);
     }
 
+    @FunctionalInterface
     public interface StatfsCallback {
         @Delegate
         int statfs(String path, Pointer stbuf);
     }
 
+    @FunctionalInterface
     public interface FlushCallback {
         @Delegate
         int flush(String path, Pointer fi);
     }
 
+    @FunctionalInterface
     public interface ReleaseCallback {
         @Delegate
         int release(String path, Pointer fi);
     }
 
+    @FunctionalInterface
     public interface FsyncCallback {
         @Delegate
         int fsync(String path, int isdatasync, Pointer fi);
     }
 
+    @FunctionalInterface
     public interface SetxattrCallback {
         @Delegate
         int setxattr(String path, String name, Pointer value, @size_t long size, int flags);
     }
 
+    @FunctionalInterface
     public interface GetxattrCallback {
         @Delegate
         int getxattr(String path, String name, Pointer value, @size_t long size);
     }
 
+    @FunctionalInterface
     public interface ListxattrCallback {
         @Delegate
         int listxattr(String path, Pointer list, @size_t long size);
     }
 
+    @FunctionalInterface
     public interface RemovexattrCallback {
         @Delegate
         int removexattr(String path, String name);
     }
 
+    @FunctionalInterface
     public interface OpendirCallback {
         @Delegate
         int opendir(String path, Pointer fi);
     }
 
+    @FunctionalInterface
     public interface ReaddirCallback {
         @Delegate
         int readdir(String path, Pointer buf, Pointer filter, @off_t long offset, Pointer fi);
     }
 
+    @FunctionalInterface
     public interface ReleasedirCallback {
         @Delegate
         int releasedir(String path, Pointer fi);
     }
 
+    @FunctionalInterface
     public interface FsyncdirCallback {
         @Delegate
         int fsyncdir(String path, Pointer fi);
     }
 
+    @FunctionalInterface
     public interface InitCallback {
         @Delegate
         public Pointer init(Pointer conn);
     }
 
+    @FunctionalInterface
     public interface DestroyCallback {
         @Delegate
         void destroy(Pointer initResult);
     }
 
+    @FunctionalInterface
     public interface AccessCallback {
         @Delegate
         void access(String path, int mask);
     }
 
+    @FunctionalInterface
     public interface CreateCallback {
         @Delegate
         void create(String path, @mode_t long mode, Pointer fi);
     }
 
+    @FunctionalInterface
     public interface FtruncateCallback {
         @Delegate
         void ftruncate(String path, @off_t long size, Pointer fi);
     }
 
+    @FunctionalInterface
     public interface FgetattrCallback {
         @Delegate
         void fgetattr(String path, Pointer stbuf, Pointer fi);
     }
 
+    @FunctionalInterface
     public interface LockCallback {
         @Delegate
         void lock(String path, Pointer fi, int cmd, Pointer flock);
     }
 
+    @FunctionalInterface
     public interface UtimensCallback {
         @Delegate
         void utimens(String path, Pointer timespec);
     }
 
+    @FunctionalInterface
     public interface BmapCallback {
         @Delegate
         void bmap(String path, @size_t long blocksize, Pointer idx);
     }
 
+    @FunctionalInterface
     public interface IoctlCallback {
         @Delegate
         void ioctl(String path, int cmd, Pointer arg, Pointer fi, @u_int32_t long flags, Pointer data);
     }
 
+    @FunctionalInterface
     public interface PollCallback {
         @Delegate
         void poll(String path, Pointer fi, Pointer ph, Pointer reventsp);
     }
 
+    @FunctionalInterface
     public interface WritebufCallback {
         @Delegate
         void write_buf(String path, Pointer buf, @off_t long off, Pointer fi);
     }
 
+    @FunctionalInterface
     public interface ReadbufCallback {
         @Delegate
         void read_buf(String path, Pointer bufp, @size_t long size, @off_t long off, Pointer fi);
     }
 
+    @FunctionalInterface
     public interface FlockCallback {
         @Delegate
         void flock(String path, Pointer fi, int op);
     }
 
+    @FunctionalInterface
     public interface FallocateCallback {
         @Delegate
         void fallocate(String path, int mode, @off_t long off, @off_t long length, Pointer fi);

--- a/src/main/java/ru/serce/jnrfuse/FuseStubFS.java
+++ b/src/main/java/ru/serce/jnrfuse/FuseStubFS.java
@@ -253,7 +253,7 @@ public class FuseStubFS extends AbstractFuseFS {
     public int write_buf(String path, FuseBufvec buf, @off_t long off, FuseFileInfo fi) {
         // TODO.
         // Some problem in implementation, but it not enabling by default
-        int res = 0;
+        int res;
         int size = (int) libFuse.fuse_buf_size(buf);
         FuseBuf flatbuf;
         FuseBufvec tmp = new FuseBufvec(Runtime.getSystemRuntime());

--- a/src/main/java/ru/serce/jnrfuse/LibFuse.java
+++ b/src/main/java/ru/serce/jnrfuse/LibFuse.java
@@ -44,5 +44,5 @@ public interface LibFuse {
      * @param user_data user data supplied in the context during the init() method
      * @return 0 on success, nonzero on failure
      */
-    int fuse_main_real(int argc, String argv[], FuseOperations op, int op_size, Pointer user_data);
+    int fuse_main_real(int argc, String[] argv, FuseOperations op, int op_size, Pointer user_data);
 }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules
squid:S1854 - Dead stores should be removed.
squid:S1197 - Array designators "[]" should be on the type, not the variable.
squid:S1609 - @FunctionalInterface annotation should be used to flag Single Abstract Method interfaces.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S1854
https://dev.eclipse.org/sonar/rules/show/squid:S1197
https://dev.eclipse.org/sonar/rules/show/squid:S1609
Please let me know if you have any questions.
George Kankava