### PR TITLE
squid:S1213 - The members of an interface declaration or class should appear in a pre-defined order

### DIFF
--- a/src/main/java/ru/serce/jnrfuse/struct/FileStat.java
+++ b/src/main/java/ru/serce/jnrfuse/struct/FileStat.java
@@ -40,33 +40,25 @@ public class FileStat extends Struct {
     public static final int ALL_WRITE = S_IWUSR | S_IWGRP | S_IWOTH;
     public static final int S_IXUGO = S_IXUSR | S_IXGRP | S_IXOTH;
 
-    public static boolean S_ISTYPE(int mode, int mask) {
-        return (mode & S_IFMT) == mask;
-    }
+    public final dev_t st_dev;      /* Device.  */
+    private final Unsigned16 pad1;
+    public final UnsignedLong st_ino;         /* File serial number.	*/
+    public final nlink_t st_nlink;     /* Link count.  */
+    public final mode_t st_mode;       /* File mode.  */
+    public final uid_t st_uid;      /* User ID of the file's owner.	*/
+    public final gid_t st_gid;      /* Group ID of the file's group.*/
+    public final dev_t st_rdev;     /* Device number, if device.  */
+    private final Unsigned16 pad2;
+    public final SignedLong st_size;        /* Size of file, in bytes.  */
+    public final blkcnt_t st_blksize;  /* Optimal block size for I/O.  */
+    public final blkcnt_t st_blocks;   /* Number 512-byte blocks allocated. */
+    public final Timespec st_atim;     /* Time of last access.  */
+    public final Timespec st_mtim;     /* Time of last modification.  */
+    public final Timespec st_ctim;     /* Time of last status change.  */
 
-    public static boolean S_ISDIR(int mode) {
-        return S_ISTYPE(mode, S_IFDIR);
-    }
-
-    public static boolean S_ISCHR(int mode) {
-        return S_ISTYPE(mode, S_IFCHR);
-    }
-
-    public static boolean S_ISBLK(int mode) {
-        return S_ISTYPE(mode, S_IFBLK);
-    }
-
-    public static boolean S_ISREG(int mode) {
-        return S_ISTYPE(mode, S_IFREG);
-    }
-
-    public static boolean S_ISFIFO(int mode) {
-        return S_ISTYPE(mode, S_IFIFO);
-    }
-
-    public static boolean S_ISLNK(int mode) {
-        return S_ISTYPE(mode, S_IFLNK);
-    }
+    public final Signed64 __unused4;
+    public final Signed64 __unused5;
+    public final Signed64 __unused6;
 
     public FileStat(Runtime runtime) {
         super(runtime);
@@ -95,25 +87,33 @@ public class FileStat extends Struct {
         __unused6 = new Signed64();
     }
 
-    public final dev_t st_dev;      /* Device.  */
-    private final Unsigned16 pad1;
-    public final UnsignedLong st_ino;         /* File serial number.	*/
-    public final nlink_t st_nlink;     /* Link count.  */
-    public final mode_t st_mode;       /* File mode.  */
-    public final uid_t st_uid;      /* User ID of the file's owner.	*/
-    public final gid_t st_gid;      /* Group ID of the file's group.*/
-    public final dev_t st_rdev;     /* Device number, if device.  */
-    private final Unsigned16 pad2;
-    public final SignedLong st_size;        /* Size of file, in bytes.  */
-    public final blkcnt_t st_blksize;  /* Optimal block size for I/O.  */
-    public final blkcnt_t st_blocks;   /* Number 512-byte blocks allocated. */
-    public final Timespec st_atim;     /* Time of last access.  */
-    public final Timespec st_mtim;     /* Time of last modification.  */
-    public final Timespec st_ctim;     /* Time of last status change.  */
+    public static boolean S_ISTYPE(int mode, int mask) {
+        return (mode & S_IFMT) == mask;
+    }
 
-    public final Signed64 __unused4;
-    public final Signed64 __unused5;
-    public final Signed64 __unused6;
+    public static boolean S_ISDIR(int mode) {
+        return S_ISTYPE(mode, S_IFDIR);
+    }
+
+    public static boolean S_ISCHR(int mode) {
+        return S_ISTYPE(mode, S_IFCHR);
+    }
+
+    public static boolean S_ISBLK(int mode) {
+        return S_ISTYPE(mode, S_IFBLK);
+    }
+
+    public static boolean S_ISREG(int mode) {
+        return S_ISTYPE(mode, S_IFREG);
+    }
+
+    public static boolean S_ISFIFO(int mode) {
+        return S_ISTYPE(mode, S_IFIFO);
+    }
+
+    public static boolean S_ISLNK(int mode) {
+        return S_ISTYPE(mode, S_IFLNK);
+    }
 
     public static FileStat of(jnr.ffi.Pointer memory) {
         FileStat stat = new FileStat(Runtime.getSystemRuntime());

--- a/src/main/java/ru/serce/jnrfuse/struct/Flock.java
+++ b/src/main/java/ru/serce/jnrfuse/struct/Flock.java
@@ -19,17 +19,17 @@ public class Flock extends BaseStruct {
     public static final int F_WRLCK = 1;	/* Write lock.	*/
     public static final int F_UNLCK = 2;	/* Remove lock.	 */
 
-    protected Flock(jnr.ffi.Runtime runtime) {
-        super(runtime);
-        pad = Platform.IS_64_BIT ? new Padding(NativeType.UCHAR, 4) : null;
-    }
-
     public final Signed16 l_type = new Signed16();     /* Type of lock: F_RDLCK, F_WRLCK, or F_UNLCK.	*/
     public final Signed16 l_whence = new Signed16();   /* Where `l_start' is relative to (like `lseek').  */
     public final __off64_t l_start = new __off64_t();  /* Offset where the lock begins.  */
     public final __off64_t l_len = new __off64_t();    /* Size of the locked area; zero means until EOF.  */
     public final pid_t l_pid = new pid_t();            /* Process holding the lock.  */
     private final Padding pad;  // for alighnment to 32
+
+    protected Flock(jnr.ffi.Runtime runtime) {
+        super(runtime);
+        pad = Platform.IS_64_BIT ? new Padding(NativeType.UCHAR, 4) : null;
+    }
 
     public static Flock of(jnr.ffi.Pointer pointer) {
         Flock flock = new Flock(jnr.ffi.Runtime.getSystemRuntime());

--- a/src/main/java/ru/serce/jnrfuse/struct/FuseBuf.java
+++ b/src/main/java/ru/serce/jnrfuse/struct/FuseBuf.java
@@ -11,10 +11,6 @@ import ru.serce.jnrfuse.flags.FuseBufFlags;
  * be supplied as a memory pointer or as a file descriptor
  */
 public class FuseBuf extends BaseStruct {
-    protected FuseBuf(jnr.ffi.Runtime runtime) {
-        super(runtime);
-    }
-
     /**
      * Size of data in bytes
      */
@@ -45,6 +41,10 @@ public class FuseBuf extends BaseStruct {
      * Used if FUSE_BUF_FD_SEEK flag is set.
      */
     public final off_t pos = new off_t();
+
+    protected FuseBuf(jnr.ffi.Runtime runtime) {
+        super(runtime);
+    }
 
     public static FuseBuf of(jnr.ffi.Pointer pointer) {
         FuseBuf buf = new FuseBuf(jnr.ffi.Runtime.getSystemRuntime());

--- a/src/main/java/ru/serce/jnrfuse/struct/FuseBufvec.java
+++ b/src/main/java/ru/serce/jnrfuse/struct/FuseBufvec.java
@@ -16,10 +16,6 @@ import jnr.ffi.Runtime;
  * @since 02.06.15
  */
 public class FuseBufvec extends BaseStruct {
-    public FuseBufvec(jnr.ffi.Runtime runtime) {
-        super(runtime);
-    }
-
     /**
      * Number of buffers in the array
      */
@@ -39,6 +35,10 @@ public class FuseBufvec extends BaseStruct {
      * Array of buffers
      */
     public final FuseBuf buf = inner(new FuseBuf(getRuntime()));
+
+    public FuseBufvec(jnr.ffi.Runtime runtime) {
+        super(runtime);
+    }
 
     public static FuseBufvec of(jnr.ffi.Pointer pointer) {
         FuseBufvec buf = new FuseBufvec(jnr.ffi.Runtime.getSystemRuntime());

--- a/src/main/java/ru/serce/jnrfuse/struct/FuseFileInfo.java
+++ b/src/main/java/ru/serce/jnrfuse/struct/FuseFileInfo.java
@@ -10,10 +10,6 @@ import jnr.ffi.Struct;
  * @since 31.05.15
  */
 public class FuseFileInfo extends Struct {
-    protected FuseFileInfo(jnr.ffi.Runtime runtime) {
-        super(runtime);
-    }
-
     /**
      * Open flags.	 Available in open() and release()
      *
@@ -66,6 +62,10 @@ public class FuseFileInfo extends Struct {
      */
     public final u_int64_t lock_owner = new u_int64_t();
 
+    protected FuseFileInfo(jnr.ffi.Runtime runtime) {
+        super(runtime);
+    }
+    
     public static FuseFileInfo of(jnr.ffi.Pointer pointer) {
         FuseFileInfo fi = new FuseFileInfo(jnr.ffi.Runtime.getSystemRuntime());
         fi.useMemory(pointer);

--- a/src/main/java/ru/serce/jnrfuse/struct/FuseOperations.java
+++ b/src/main/java/ru/serce/jnrfuse/struct/FuseOperations.java
@@ -13,10 +13,6 @@ import static ru.serce.jnrfuse.FuseCallbacks.*;
  * @since 30.05.15
  */
 public class FuseOperations extends BaseStruct {
-    public FuseOperations(Runtime runtime) {
-        super(runtime);
-    }
-
     public final Func<GetAttrCallback> getattr = func(GetAttrCallback.class);
     public final Func<ReadlinkCallback> readlink = func(ReadlinkCallback.class);
     @Deprecated
@@ -97,4 +93,8 @@ public class FuseOperations extends BaseStruct {
     public final Func<ReadbufCallback> read_buf = func(ReadbufCallback.class);
     public final Func<FlockCallback> flock = func(FlockCallback.class);
     public final Func<FallocateCallback> fallocate = func(FallocateCallback.class);
+
+    public FuseOperations(Runtime runtime) {
+        super(runtime);
+    }
 }

--- a/src/main/java/ru/serce/jnrfuse/struct/FusePollhandle.java
+++ b/src/main/java/ru/serce/jnrfuse/struct/FusePollhandle.java
@@ -17,15 +17,15 @@ import jnr.ffi.BaseStruct;
  * @since 02.06.15
  */
 public class FusePollhandle extends BaseStruct {
-    protected FusePollhandle(jnr.ffi.Runtime runtime) {
-        super(runtime);
-    }
-
     public final Unsigned64 kh = new Unsigned64();
     // TODO struct fuse_chan *ch;
     public final Pointer ch = new Pointer();
     // TODO struct fuse_ll *f;
     public final Pointer f = new Pointer();
+
+    protected FusePollhandle(jnr.ffi.Runtime runtime) {
+        super(runtime);
+    }
 
     public static FusePollhandle of(jnr.ffi.Pointer pointer) {
         FusePollhandle ph = new FusePollhandle(jnr.ffi.Runtime.getSystemRuntime());

--- a/src/main/java/ru/serce/jnrfuse/struct/Statvfs.java
+++ b/src/main/java/ru/serce/jnrfuse/struct/Statvfs.java
@@ -24,11 +24,6 @@ public class Statvfs extends BaseStruct {
     public static final int ST_NODIRATIME = 2048;/* Do not update directory access times.  */
     public static final int ST_RELATIME = 4096;	/* Update atime relative to mtime/ctime.  */
 
-
-    public Statvfs(jnr.ffi.Runtime runtime) {
-        super(runtime);
-    }
-
     public final UnsignedLong f_bsize = new UnsignedLong();  /* file system block size */
     public final UnsignedLong f_frsize = new UnsignedLong(); /* fragment size */
     public final fsblkcnt64_t f_blocks = new fsblkcnt64_t(); /* size of fs in f_frsize units */
@@ -48,6 +43,9 @@ public class Statvfs extends BaseStruct {
     public final UnsignedLong f_namemax = new UnsignedLong();/* maximum filename length */
     public final Signed32[] __f_spare = array(new Signed32[6]);
 
+    public Statvfs(jnr.ffi.Runtime runtime) {
+        super(runtime);
+    }
 
     public static Statvfs of(jnr.ffi.Pointer pointer) {
         Statvfs statvfs = new Statvfs(jnr.ffi.Runtime.getSystemRuntime());

--- a/src/main/java/ru/serce/jnrfuse/struct/Timespec.java
+++ b/src/main/java/ru/serce/jnrfuse/struct/Timespec.java
@@ -9,12 +9,12 @@ import jnr.ffi.BaseStruct;
  * @since 31.05.15
  */
 public class Timespec extends BaseStruct {
+    public final __time_t tv_sec = new __time_t();          /* seconds */
+    public final SignedLong tv_nsec = new SignedLong();     /* nanoseconds */
+
     protected Timespec(jnr.ffi.Runtime runtime) {
         super(runtime);
     }
-
-    public final __time_t tv_sec = new __time_t();          /* seconds */
-    public final SignedLong tv_nsec = new SignedLong();     /* nanoseconds */
 
     public static Timespec of(jnr.ffi.Pointer pointer) {
         Timespec timespec = new Timespec(jnr.ffi.Runtime.getSystemRuntime());


### PR DESCRIPTION
This pull request is focused on resolving occurrence of Sonar rule
squid:S1213 - The members of an interface declaration or class should appear in a pre-defined order.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S1213
Please let me know if you have any questions.
George Kankava