### PR TITLE
Refactor umount to be reusable

### DIFF
--- a/src/main/java/ru/serce/jnrfuse/AbstractFuseFS.java
+++ b/src/main/java/ru/serce/jnrfuse/AbstractFuseFS.java
@@ -7,9 +7,9 @@ import jnr.ffi.Struct;
 import jnr.ffi.mapper.FromNativeConverter;
 import jnr.ffi.provider.jffi.ClosureHelper;
 import ru.serce.jnrfuse.struct.*;
+import ru.serce.jnrfuse.utils.MountUtils;
 import ru.serce.jnrfuse.utils.SecurityUtils;
 
-import java.io.IOException;
 import java.lang.reflect.Method;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -283,17 +283,8 @@ public abstract class AbstractFuseFS implements FuseFS {
         if (!mounted.get()) {
             return;
         }
-        try {
-            String mountPath = mountPoint.toAbsolutePath().toString();
-            try {
-                new ProcessBuilder("fusermount", "-u", "-z", mountPath).start();
-            } catch (IOException e) {
-                new ProcessBuilder("umount", mountPath).start();
-            }
-            mounted.set(false);
-        } catch (IOException e) {
-            throw new FuseException("Unable to umount FS", e);
-        }
+        MountUtils.umount(mountPoint);
+        mounted.set(false);
     }
 
     protected String getFSName() {

--- a/src/main/java/ru/serce/jnrfuse/utils/MountUtils.java
+++ b/src/main/java/ru/serce/jnrfuse/utils/MountUtils.java
@@ -1,0 +1,25 @@
+package ru.serce.jnrfuse.utils;
+
+import ru.serce.jnrfuse.FuseException;
+
+import java.io.IOException;
+import java.nio.file.Path;
+
+
+public class MountUtils {
+    /**
+     * Perform/force a umount at the provided Path
+     */
+    public static void umount(Path mountPoint) {
+        try {
+            String mountPath = mountPoint.toAbsolutePath().toString();
+            try {
+                new ProcessBuilder("fusermount", "-u", "-z", mountPath).start();
+            } catch (IOException e) {
+                new ProcessBuilder("umount", mountPath).start();
+            }
+        } catch (IOException e) {
+            throw new FuseException("Unable to umount FS", e);
+        }
+    }
+}


### PR DESCRIPTION
This is useful if a fuse fs didn't get umounted properly.

In the BaseFsTest is a blockingMount method. Is this one still needed? or what is the difference using the blocking argument in mount?