### PR TITLE
Included ENOATTR, ENOTSUP, EACCES in ErrorCodes

### DIFF
--- a/src/main/java/ru/serce/jnrfuse/ErrorCodes.java
+++ b/src/main/java/ru/serce/jnrfuse/ErrorCodes.java
@@ -1049,6 +1049,27 @@ public class ErrorCodes {
         return 54;
     }
 
+    /**
+     * The extended attribute does not exist
+     */
+    public static int ENOATTR() {
+        return 93;
+    }
+    
+    /**
+     * The file system does not support extended attributes or has the feature disabled
+     */
+    public static int ENOTSUP() {
+        return 45;
+    }
+
+    /**
+     * Search permission is denied for a component of path or the attribute is not allowed to be read (e.g. an ACL prohibits reading the attributes of this file)
+     */
+    public static int EACCES() {
+        return Errno.EACCES.intValue();
+    }
+    
     private ErrorCodes() {
     }
 }

--- a/src/main/java/ru/serce/jnrfuse/ErrorCodes.java
+++ b/src/main/java/ru/serce/jnrfuse/ErrorCodes.java
@@ -1062,13 +1062,6 @@ public class ErrorCodes {
     public static int ENOTSUP() {
         return 45;
     }
-
-    /**
-     * Search permission is denied for a component of path or the attribute is not allowed to be read (e.g. an ACL prohibits reading the attributes of this file)
-     */
-    public static int EACCES() {
-        return Errno.EACCES.intValue();
-    }
     
     private ErrorCodes() {
     }


### PR DESCRIPTION
I retrieved the integer values from https://opensource.apple.com/source/xnu/xnu-1456.1.26/bsd/sys/errno.h (ENOATTR 93, ENOTSUP 45) and cross checked https://github.com/jnr/jnr-constants/blob/master/src/main/java/jnr/constants/platform/Errno.java, if those error codes were already available there (only EACCES was).

It seems from `errno.h`, that error code 45 is used for multiple errors and it is also redundant to error `EL2NSYNC` in `ErrorCodes`, but I could not test it, as I don't have Mac OS at hand. Maybe someone else could test it?