### PR TITLE
Move st_birthtime field out of the MacOS specific section since it is also used by Windows

### DIFF
--- a/src/main/java/ru/serce/jnrfuse/struct/FileStat.java
+++ b/src/main/java/ru/serce/jnrfuse/struct/FileStat.java
@@ -190,13 +190,13 @@ public class FileStat extends Struct {
     public final Timespec st_atim;     /* Time of last access.  */
     public final Timespec st_mtim;     /* Time of last modification.  */
     public final Timespec st_ctim;     /* Time of last status change.  */
+    public final Timespec st_birthtime;/* Time of file creation(birth) */
 
     public final Signed64 __unused4;
     public final Signed64 __unused5;
     public final Signed64 __unused6;
 
     /** MacOS specific */
-    public final Timespec st_birthtime;     /* time of file creation(birth) */
     public final u_int32_t st_flags;
     public final u_int32_t st_gen;
 


### PR DESCRIPTION
![without setting st_birthtime](https://user-images.githubusercontent.com/11398547/40187955-1db9eec0-59f9-11e8-858b-3b7aced3a77d.png)
![with settings st_birthtime](https://user-images.githubusercontent.com/11398547/40187956-1dd56452-59f9-11e8-98cd-41e73cdfdb62.png)