### PR TITLE
Make jnr-fuse work with jnr-ffi 2.1.8

### DIFF
--- a/src/main/java/jnr/ffi/provider/jffi/ClosureHelper.java
+++ b/src/main/java/jnr/ffi/provider/jffi/ClosureHelper.java
@@ -11,11 +11,12 @@ import ru.serce.jnrfuse.FuseException;
 
 import java.lang.reflect.Field;
 import java.util.Collections;
+import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
 public class ClosureHelper {
 
-    private final AsmClassLoader classLoader;
+    private final AsmClassLoader asmClassLoader;
     private final CompositeTypeMapper ctm;
     private final SimpleNativeContext ctx;
 
@@ -32,7 +33,7 @@ public class ClosureHelper {
             return result;
         }
         result = (FromNativeConverter<T, Pointer>) ClosureFromNativeConverter.
-                getInstance(Runtime.getSystemRuntime(), DefaultSignatureType.create(closureClass, (FromNativeContext) ctx), classLoader, ctm);
+                getInstance(Runtime.getSystemRuntime(), DefaultSignatureType.create(closureClass, (FromNativeContext) ctx), asmClassLoader, ctm);
         cache.putIfAbsent(closureClass, result);
         return result;
     }
@@ -49,10 +50,11 @@ public class ClosureHelper {
     private ClosureHelper() {
         try {
             ClosureManager closureManager = jnr.ffi.Runtime.getSystemRuntime().getClosureManager();
-            Field classLoaderField = NativeClosureManager.class.getDeclaredField("classLoader");
-            classLoaderField.setAccessible(true);
+            Field asmClassLoadersField = NativeClosureManager.class.getDeclaredField("asmClassLoaders");
+            asmClassLoadersField.setAccessible(true);
 
-            classLoader = (AsmClassLoader) classLoaderField.get(closureManager);
+            Map<ClassLoader, AsmClassLoader> asmClassLoaders = (Map<ClassLoader, AsmClassLoader>) asmClassLoadersField.get(closureManager);
+            asmClassLoader = asmClassLoaders.get(ClosureHelper.class.getClassLoader());
 
             Field typeMapperField = NativeClosureManager.class.getDeclaredField("typeMapper");
             typeMapperField.setAccessible(true);

--- a/src/test/java/ru/serce/jnrfuse/struct/MemoryFsTest.java
+++ b/src/test/java/ru/serce/jnrfuse/struct/MemoryFsTest.java
@@ -11,6 +11,7 @@ import java.io.PrintWriter;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import static org.junit.Assert.*;
 
@@ -30,8 +31,10 @@ public class MemoryFsTest extends BaseFsTest {
                 writer.print("test2");
             }
 
-            String text = Files.lines(fileOne.toPath()).collect(Collectors.joining());
-            assertEquals("file content doesn't match what was written", "test1test2", text);
+            try (Stream<String> lines = Files.lines(fileOne.toPath())) {
+                String text = lines.collect(Collectors.joining());
+                assertEquals("file content doesn't match what was written", "test1test2", text);
+            }
 
             assertTrue("file can't be deleted", fileOne.delete());
             assertFalse("file mustn't exist", fileOne.exists());


### PR DESCRIPTION
There was a change in jnr-ffi 2.1.8: https://github.com/jnr/jnr-ffi/commit/82f954fcc854fd37138ee037c95f3e213f0acad7#diff-6d69e8ad9f244cd630712601ca106d13