### PR TITLE
fixes SerCeMan/jnr-fuse#63

### DIFF
--- a/src/main/java/ru/serce/jnrfuse/utils/WinPathUtils.java
+++ b/src/main/java/ru/serce/jnrfuse/utils/WinPathUtils.java
@@ -66,7 +66,13 @@ public class WinPathUtils {
         if (!libraryPath.endsWith("\\")) {
             libraryPath += "\\";
         }
-        return libraryPath + "bin\\winfsp-x64.dll";
+
+        String fileName = "winfsp-x64.dll";
+        String osArch = System.getProperty("os.arch");
+        if (osArch.equalsIgnoreCase("x86")) {
+            fileName = "winfsp-x86.dll";
+        }
+        return libraryPath + "bin\\" + fileName;
     }
 
     private static String extractRegInstallRecord() {


### PR DESCRIPTION
 Where library is unable to load, because JRE is x86 and not x64