### PR TITLE
Fixes #73 by removing mount point check

### DIFF
--- a/src/main/java/ru/serce/jnrfuse/AbstractFuseFS.java
+++ b/src/main/java/ru/serce/jnrfuse/AbstractFuseFS.java
@@ -257,12 +257,6 @@ public abstract class AbstractFuseFS implements FuseFS {
 
         final String[] args = arg;
         try {
-            if (!Platform.IS_WINDOWS) {
-                // winfsp requires non-existing directory to be provided
-                if (!Files.isDirectory(mountPoint)) {
-                    throw new FuseException("Mount point should be directory");
-                }
-            }
             if (SecurityUtils.canHandleShutdownHooks()) {
                 java.lang.Runtime.getRuntime().addShutdownHook(new Thread(this::umount));
             }


### PR DESCRIPTION
Partial undo of 6cbdc4d: Don't exist whether a mount point is an existing directory. This has already been removed for Windows in 4b97249. Rationale is discussed in issue #73.