### PR TITLE
Checks java file encoding on windows (PR #75)

### DIFF
--- a/src/main/java/ru/serce/jnrfuse/AbstractFuseFS.java
+++ b/src/main/java/ru/serce/jnrfuse/AbstractFuseFS.java
@@ -62,7 +62,11 @@ public abstract class AbstractFuseFS implements FuseFS {
                 }
                 break;
             case WINDOWS:
-                String winFspPath = WinPathUtils.getWinFspPath();
+        		if (!System.getProperty("file.encoding").equals("UTF-8"))
+        		{	
+        			System.out.println("UTF-8 encoding required! Current encoding: " + System.getProperty("file.encoding"));
+        		}
+        		String winFspPath = WinPathUtils.getWinFspPath();
             	libFuse = loader.load(winFspPath);
             	break;
             default:


### PR DESCRIPTION
This implementation checks whether the UTF-8 file encoding is set when working on windows. If the wrong file encoding is set mounting the drive works, but accessing and working on it doesn't work.

Details see pull request #75