### PR TITLE
change jcenter URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ dependencies {
     <repository>
         <id>central</id>
         <name>bintray</name>
-        <url>https://dl.bintray.com/serce/maven</url>
+        <url>https://jcenter.bintray.com</url>
     </repository>
 </repositories>
 


### PR DESCRIPTION
Since the package is published to jcenter, just having jcenter should be enough for maven to resolve it. Just tested :) 