### PR TITLE
Allow usage of other libraries support fuse on windows

### DIFF
--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -20,7 +20,8 @@ brew cask install osxfuse
 
 ## Windows
 
-[`winfsp`](https://github.com/billziss-gh/winfsp) needs to be installed.
+A library implementing the fuse API needs to be installed and the library path must be set via the `jnr-fuse.windows.libpath` system property.
+If the system property is not set, jnr-fuse falls back to [`winfsp`](https://github.com/billziss-gh/winfsp), if it is installed.
 ```batch
 choco install winfsp
 ```

--- a/src/main/java/ru/serce/jnrfuse/AbstractFuseFS.java
+++ b/src/main/java/ru/serce/jnrfuse/AbstractFuseFS.java
@@ -26,6 +26,7 @@ import java.util.stream.Collectors;
 public abstract class AbstractFuseFS implements FuseFS {
 
     private static final int TIMEOUT = 2000; // ms
+    private static final String PROPERTY_WINLIB_PATH = "jnr-fuse.windows.libpath";
     private static final String[] osxFuseLibraries = {"fuse4x", "osxfuse", "macfuse", "fuse"};
 
     private Set<String> notImplementedMethods;
@@ -57,8 +58,9 @@ public abstract class AbstractFuseFS implements FuseFS {
                 }
                 break;
             case WINDOWS:
-                String winFspPath = WinPathUtils.getWinFspPath();
-                libFuse = LibraryLoader.create(LibFuse.class).failImmediately().load(winFspPath);
+                //see if the property is set, otherwise use winfsp
+                String windowsLibPath = System.getProperty(PROPERTY_WINLIB_PATH, WinPathUtils.getWinFspPath());
+                libFuse = LibraryLoader.create(LibFuse.class).failImmediately().load(windowsLibPath);
                 break;
             case LINUX:
             default: // Assume linux since we have no further OS evidence

--- a/src/test/java/ru/serce/jnrfuse/struct/HelloFuseTest.java
+++ b/src/test/java/ru/serce/jnrfuse/struct/HelloFuseTest.java
@@ -1,6 +1,5 @@
 package ru.serce.jnrfuse.struct;
 
-import jnr.posix.util.Platform;
 import org.junit.Test;
 import ru.serce.jnrfuse.examples.HelloFuse;
 
@@ -15,13 +14,6 @@ import static org.junit.Assert.assertTrue;
 public class HelloFuseTest extends BaseFsTest {
     @Test
     public void testReadHello() throws Exception {
-        if (Platform.IS_WINDOWS) {
-            // There is a winfsp speciality due to which the FS can't be mounted, unmounted, and then mounted again
-            // https://github.com/billziss-gh/cgofuse/issues/21#issuecomment-345307900
-            // Therefore only one mounting test test is currently enabled. Given that HelloFS is not as valuable as
-            // MemoryFS it is disabled.
-            return;
-        }
         HelloFuse stub = new HelloFuse();
 
         Path tmpDir = tempPath();


### PR DESCRIPTION
This PR adds the feature, that developers can use also other libraries implementing the fuse api than winfsp (e.g. [Dokany](https://dokan-dev.github.io/)).

To change the underlying lib, the system property `jnr-fuse.windows.libPath` needs to be set with the path pointing to dll file. If the property is not set, winfsp is used if possible.

Additionally, a check is removed in the `HelloFuseTest` class, since the underlying problem is solved on the side of winfsp.