### PR TITLE
Update Gradle build

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,9 +1,8 @@
 plugins {
-    id 'java'
-    id 'idea'
-    id 'com.github.johnrengelman.shadow' version '4.0.2'
+    id 'java-library'
+    id 'com.github.johnrengelman.shadow' version '6.1.0'
     id 'net.researchgate.release' version '2.8.1'
-    id 'maven'
+    id 'io.github.gradle-nexus.publish-plugin' version '1.0.0'
     id 'maven-publish'
     id 'signing'
 }
@@ -12,58 +11,35 @@ repositories {
     jcenter()
 }
 
-sourceCompatibility = 1.8
-targetCompatibility = 1.8
-
-idea {
-    project {
-        jdkName = '1.8'
-        languageLevel = '1.8'
+java {
+    withSourcesJar()
+    withJavadocJar()
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(8)
     }
 }
 
 shadowJar {
-    classifier = 'shadow'
+    archiveClassifier = 'shadow'
     relocate 'org.objectweb.asm', 'org.objectweb.asm.shaded'
 }
 
-
-if (JavaVersion.current().isJava8Compatible()) {
-    allprojects {
-        tasks.withType(Javadoc) {
-            options.addStringOption('Xdoclint:none', '-quiet')
-        }
-    }
-}
-
-task sourcesJar(type: Jar, dependsOn: classes) {
-    classifier = 'sources'
-    from sourceSets.main.allSource
-}
-
-task javadocJar(type: Jar, dependsOn: javadoc) {
-    classifier = 'javadoc'
-    from javadoc.destinationDir
-}
-
-artifacts {
-    archives sourcesJar
-    archives javadocJar
-    archives shadowJar
+tasks.withType(Javadoc).configureEach {
+    options.addStringOption('Xdoclint:none', '-quiet')
 }
 
 dependencies {
-    compile 'com.github.jnr:jnr-ffi:2.1.12'
-    compile 'com.github.jnr:jnr-posix:3.0.54'
-    compile 'com.github.jnr:jnr-constants:0.9.15'
+    implementation 'com.github.jnr:jnr-ffi:2.1.12'
+    implementation 'com.github.jnr:jnr-posix:3.0.54'
+    implementation 'com.github.jnr:jnr-constants:0.9.15'
 
-    testCompile group: 'junit', name: 'junit', version: '4.13.2'
+    testImplementation 'junit:junit:4.13.2'
 }
 
 release {
     newVersionCommitMessage = '[jnr-fuse release] - '
     preTagCommitMessage = '[jnr-fuse release] - pre tag commit: '
-    buildTasks = ['clean', 'assemble', 'publish']
+    buildTasks = ['clean', 'assemble', 'publishToSonatype', 'closeAndReleaseSonatypeStagingRepository']
 }
 
 publishing {
@@ -71,10 +47,6 @@ publishing {
         mavenJava(MavenPublication) {
             artifactId = 'jnr-fuse'
             from components.java
-
-            artifact sourcesJar
-            artifact javadocJar
-            artifact shadowJar
 
             versionMapping {
                 usage('java-api') {
@@ -114,18 +86,28 @@ publishing {
 
     repositories {
         maven {
-            def releasesRepoUrl = 'https://oss.sonatype.org/service/local/staging/deploy/maven2'
-            def snapshotsRepoUrl = 'https://oss.sonatype.org/content/repositories/snapshots'
-            url = version.endsWith('SNAPSHOT') ? snapshotsRepoUrl : releasesRepoUrl
+            // A test repository in the build repository
+            // allowing easy verification of published artifacts
+            name = 'projectLocal'
+            url = file("${buildDir}/repo")
+        }
+    }
+}
 
-            credentials {
-                username System.getenv("SONATYPE_LOGIN")
-                password System.getenv("SONATYPE_PASSWORD")
-            }
+nexusPublishing {
+    repositories {
+        sonatype {
+            username.set(providers.environmentVariable("SONATYPE_LOGIN").forUseAtConfigurationTime())
+            password.set(providers.environmentVariable("SONATYPE_PASSWORD").forUseAtConfigurationTime())
         }
     }
 }
 
 signing {
     sign publishing.publications.mavenJava
+    setRequired {
+        gradle.taskGraph.allTasks.any {
+            it.name == 'publishToSonatype'
+        }
+    }
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.8.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.8.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
This commit upgrades to Gradle 6.8.3 and makes some required changes
in order to prepare for Gradle 7 (in particular, get rid of the old
`compile` dependencies).

It upgrades the publishing mechanism to use the first-class support
for generating sources/javadocs.

In addition, this integrates with the toolchain support, simplifying
the build and making sure that a Java 8 JVM is used for building and
testing.