### PR TITLE
Force unmount on Mac/Linux.

### DIFF
--- a/src/main/java/ru/serce/jnrfuse/utils/MountUtils.java
+++ b/src/main/java/ru/serce/jnrfuse/utils/MountUtils.java
@@ -16,7 +16,7 @@ public class MountUtils {
             new ProcessBuilder("fusermount", "-u", "-z", mountPath).start();
         } catch (IOException e) {
             try {
-                new ProcessBuilder("umount", mountPath).start().waitFor();
+                new ProcessBuilder("umount", "-f", mountPath).start().waitFor();
             } catch (InterruptedException ie) {
                 Thread.currentThread().interrupt();
                 throw new FuseException("Unable to umount FS", e);


### PR DESCRIPTION
On Mac OS X, if there is an operation in progress the umount() function returns without an error but the operation doesn't succeed. We need to force the umount() in that case.