### PR TITLE
fix dependency declaration

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,9 +29,9 @@ tasks.withType(Javadoc).configureEach {
 }
 
 dependencies {
-    implementation 'com.github.jnr:jnr-ffi:2.2.7'
-    implementation 'com.github.jnr:jnr-posix:3.1.10'
-    implementation 'com.github.jnr:jnr-constants:0.10.2'
+    api 'com.github.jnr:jnr-ffi:2.2.7'
+    api 'com.github.jnr:jnr-posix:3.1.10'
+    api 'com.github.jnr:jnr-constants:0.10.2'
 
     testImplementation 'junit:junit:4.13.2'
 }


### PR DESCRIPTION
fixes #139:

The jnr libs are public api, not just hidden implementation required at runtime. Downstream projects are expected to deal with packages like `jnr.constants.platform`, `jnr.ffi`, or `jnr.ffi.types`.

_Edit:_ This [SO post](https://stackoverflow.com/a/44419574/4014509) explains the difference between `api` and `implementation`:

> If you are a library mantainer you should use `api` for every dependency which is needed for the public API of your library, while use `implementation` for test dependencies or dependencies which must not be used by the final users.