### PR TITLE
update INSTALLATION.md

### DIFF
--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -15,7 +15,7 @@ sudo apt-get install libfuse-dev
 [`osxfuse`](https://osxfuse.github.io) needs to be installed.
 
 ```bash
-brew cask install osxfuse
+brew install --cask osxfuse
 ```
 
 ## Windows


### PR DESCRIPTION
Since homebrew was released from version 2.5.11, the command cask has been canceled,

For example, our original installation command was:

`brew cask install osxfuse`

Now it needs to be changed to:

`brew install --cask osxfuse`