### PR TITLE
Add AArch64 (64-bit ARM) Linux support

### DIFF
--- a/src/main/java/ru/serce/jnrfuse/struct/FileStat.java
+++ b/src/main/java/ru/serce/jnrfuse/struct/FileStat.java
@@ -116,6 +116,8 @@ public class FileStat extends Struct {
             //graveyard
             pad1 = null;
             pad2 = null;
+            __pad1 = null;
+            __pad2 = null;
             __unused4 = null;
             __unused5 = null;
             __unused6 = null;
@@ -138,11 +140,39 @@ public class FileStat extends Struct {
             // graveyard
             pad1 = null;
             pad2 = null;
+            __pad1 = null;
+            __pad2 = null;
             __unused4 = null;
             __unused5 = null;
             __unused6 = null;
             st_flags = null;
             st_gen = null;
+        } else if (Platform.IS_LINUX && "aarch64".equals(Platform.ARCH)) {
+            st_dev = new dev_t();
+            st_ino = new ino_t();
+            st_mode = new mode_t();
+            st_nlink = new nlink_t();
+            st_uid = new uid_t();
+            st_gid = new gid_t();
+            st_rdev = new dev_t();
+            __pad1 = new Unsigned64();
+            st_size = new off_t();
+            st_blksize = new blksize_t();
+            __pad2 = new Unsigned32();
+            st_blocks = new blkcnt_t();
+            st_atim = inner(new Timespec(getRuntime()));
+            st_mtim = inner(new Timespec(getRuntime()));
+            st_ctim = inner(new Timespec(getRuntime()));
+            __unused4 = new Signed64();
+
+            //graveyard
+            pad1 = null;
+            pad2 = null;
+            st_birthtime = null;
+            st_flags = null;
+            st_gen = null;
+            __unused5 = null;
+            __unused6 = null;
         } else {
             st_dev = new dev_t();
             pad1 = IS_32_BIT ? new Unsigned16() : null;
@@ -172,11 +202,15 @@ public class FileStat extends Struct {
             st_birthtime = null;
             st_flags = null;
             st_gen = null;
+            __pad1 = null;
+            __pad2 = null;
         }
     }
 
     public final dev_t st_dev;      /* Device.  */
     private final Unsigned16 pad1;
+    private final Unsigned64 __pad1;
+    private final Unsigned32 __pad2;
     public final NumberField st_ino;         /* File serial number.	*/
     public final NumberField st_nlink;     /* Link count.  */
     public final NumberField st_mode;       /* File mode.  */

--- a/src/test/java/ru/serce/jnrfuse/struct/StructSizeTest.java
+++ b/src/test/java/ru/serce/jnrfuse/struct/StructSizeTest.java
@@ -43,7 +43,7 @@ public class StructSizeTest {
                     pair(WINDOWS, platformSize(88, 88)), //
                     pair(DARWIN, platformSize(64, 64)))),
             pair(FileStat.class, asMap(
-                    pair(LINUX, platformSize(96, 144)), //
+                    pair(LINUX, platformSize(96, Platform.ARCH.equals("aarch64") ? 128 : 144)), //
                     pair(WINDOWS, platformSize(128, 128)), //
                     pair(DARWIN, platformSize(96, 144)))),
             pair(FuseFileInfo.class, asMap(


### PR DESCRIPTION
Add support for the struct layout of AArch64 Linux, found on AWS Graviton. Fixes #171.

```
pahole -C stat /usr/lib/aarch64-linux-gnu/libc.so.6

struct stat {
	__dev_t                    st_dev;               /*     0     8 */
	__ino_t                    st_ino;               /*     8     8 */
	__mode_t                   st_mode;              /*    16     4 */
	__nlink_t                  st_nlink;             /*    20     4 */
	__uid_t                    st_uid;               /*    24     4 */
	__gid_t                    st_gid;               /*    28     4 */
	__dev_t                    st_rdev;              /*    32     8 */
	__dev_t                    __pad1;               /*    40     8 */
	__off_t                    st_size;              /*    48     8 */
	__blksize_t                st_blksize;           /*    56     4 */
	int                        __pad2;               /*    60     4 */
	/* --- cacheline 1 boundary (64 bytes) --- */
	__blkcnt_t                 st_blocks;            /*    64     8 */
	struct timespec            st_atim;              /*    72    16 */
	struct timespec            st_mtim;              /*    88    16 */
	struct timespec            st_ctim;              /*   104    16 */
	int                        __glibc_reserved[2];  /*   120     8 */

	/* size: 128, cachelines: 2, members: 16 */
};
```

This is very similar to jnr/jnr-posix/issues/164.