### PR TITLE
Fix MemoryFS performance issue with big files

### DIFF
--- a/src/main/java/ru/serce/jnrfuse/examples/MemoryFS.java
+++ b/src/main/java/ru/serce/jnrfuse/examples/MemoryFS.java
@@ -150,7 +150,7 @@ public class MemoryFS extends FuseStubFS {
             synchronized (this) {
                 if (maxWriteIndex > contents.capacity()) {
                     // Need to create a new, larger buffer
-                    ByteBuffer newContents = ByteBuffer.allocate(maxWriteIndex);
+                    ByteBuffer newContents = ByteBuffer.allocate(maxWriteIndex * 2);
                     newContents.put(contents);
                     contents = newContents;
                 }


### PR DESCRIPTION
I tried to copy a big file to the MemoryFs, and realized it's incredible slow. After some investigation I found out that this line of code copies the whole file every single time some bytes gets appended to it, making the writing process slower and slower the bigger the file gets. After this fix I measured over 50-100x performance increase with a 1GB file.